### PR TITLE
Unfiltered Network Share Names Allows Arbitrary Command Execution & Arbitrary File Write

### DIFF
--- a/SMBList.pl
+++ b/SMBList.pl
@@ -118,6 +118,7 @@ BLOCKOUT
 			printf '%-35s %-35s %-35s %-35s', $share, $username, $password, 'Running...';
 			#print "smbclient -N -A '$tempAuthFile' '$share' -c 'recurse;dir' 2>&1 > temporary_running_file.txt";
 			#die;
+            $share =~ s/'/'\\''/g;
 			my $smbclient_cmd = `timeout $inputMaxExec smbclient -N -A '$tempAuthFile' '$share' -c 'recurse;dir' 2>&1 > temporary_running_file.txt`;
 			unlink($tempAuthFile);
 			print "\b"x35;
@@ -127,8 +128,9 @@ BLOCKOUT
 			my @lines = split "\n", $tempFile;
 			unless ($lines[0] =~ /BAD_NETWORK_NAME/ or $lines[0] =~ /ACCESS_DENIED/ or $lines[0] =~ /LOGON_FAILURE/ or $lines[0] =~ /NT_STATUS_UNSUCCESSFUL/ or $lines[0] =~ /INVALID_DEVICE_REQUEST/ or $lines[0] =~ /ACCOUNT_LOCKED_OUT/ or $lines[0] =~ /WRONG_PASSWORD/ or $lines[0] =~ /NETWORK_UNREACHABLE/ or $lines[0] =~ /NO_DATA/ or $lines[0] =~ /NT_STATUS_HOST_UNREACHABLE/ or $lines[0] =~ /NT_STATUS_NO_LOGON_SERVERS/) {
 				my $newShareFileName = $share;
-				$newShareFileName =~ s/\\\\//;
-				$newShareFileName =~ s/\\/_/;
+				$newShareFileName =~ s/\\\\//g;
+				$newShareFileName =~ s/\\/_/g;
+				$newShareFileName =~ s/\//-/g;
 				my $currentPath = "";
 				my $fh_share_file;
 				open($fh_share_file, ">$newShareFileName") or die "Could not save a new file! $!\n";


### PR DESCRIPTION
There is a vulnerability in SMBList.pl which allows an attacker (e.g. server administrator) to execute arbitrary commands on the system on which the script was executed.


**Attack path 1:**
    1. Create a share which contains ' in the name in order to break out of the string in SMBList.pl line 121

```my $smbclient_cmd = `timeout $inputMaxExec smbclient -N -A '$tempAuthFile' '$share' -c 'recurse;dir' 2>&1 > temporary_running_file.txt`;```

    **Samba config:**
    [Data' -c 'exit';touch /tmp/oops;echo 'oops]
      comment = My Partition
      create mask = 0775
      directory mask = 0775
      browseable = yes
      path = /asd asd
      guest ok = yes
      available = yes
      public = yes
      writable = yes

2. Run SMBHunt.pl and something like the following will be returned:
   ``` \\172.11.132.1\Data' -c 'exit';touch /tmp/oops;echo 'oops```

3. Run SMBList.pl, a file (/tmp/oops) is now created. This can of course be changed to any command.

**Fix: escape $share, such as via:**
$share =~ s/'/'\\''/g;


**Attack path 2:**
After indexing a fileshare, the name of the fileshare is used within perl's open() function. This may lead to an issue if
- characters are used within the filename, which are however not allowed as part of linux filesystem (e.g. /) => script does not work
- a directory exist within the same folder as the script which matches the name of a share previously scanned (e.g. 172.11.132.1_foo). In this case an attacker can use ../ to navigate through the local file system and under circumstances overwrite files. For example the share name \\172.11.132.1\foo/../../../../../etc/passwd will be transformed to 172.11.132.1_foo../../../../../etc/passwd and passed to the open() function.

**Fix:**
replace / with -
